### PR TITLE
Add template for PyGMT tutorial with only comments

### DIFF
--- a/refresher/pygmt_template.ipynb
+++ b/refresher/pygmt_template.ipynb
@@ -1,0 +1,568 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "0afcaf70-c449-44cd-8212-ecac3f869fae",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "# 1. PyGMT Refresher Webinar\n",
+    "\n",
+    "## 1.1 Learning Objectives\n",
+    "\n",
+    "- **1.2**: Provide an overview of PyGMT\n",
+    "- **2.1**: Load x,y,z data into a pandas.DataFrame\n",
+    "- **2.2**: Plot tabular data\n",
+    "- **2.3**: Grid x,y,z data\n",
+    "- **2.4**: Plot gridded data\n",
+    "- **3.1**: Add scale bar\n",
+    "- **3.2**: Add insets\n",
+    "- **4.1**: Create subplots\n",
+    "- **5.1**: Configure PyGMT settings\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "40716036-d0d5-4001-93bd-306a549318ad",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "## 1.2 PyGMT Overview\n",
+    "\n",
+    "### What is [PyGMT](https://pygmt.org/)?\n",
+    "\n",
+    "- PyGMT is an open-source Python package for geospatial data processing, analysis, and visualization.\n",
+    "- PyGMT is designed to:\n",
+    "  - support rich display in Jupyter notebooks.\n",
+    "  - improve access to the Generic Mapping Tools (GMT).\n",
+    "  - integrate smoothly with scientific Python packages (e.g., NumPy, pandas, xarray, GeoPandas).\n",
+    "\n",
+    "### How does PyGMT compare to other common Python packages and software?\n",
+    "\n",
+    "**How does PyGMT differ from GMT?**\n",
+    "\n",
+    "- PyGMT provides a Python interface for the GMT C API, which has been traditionally accessed\n",
+    "  through the command line.\n",
+    "\n",
+    "**How does PyGMT differ from Matplotlib?**\n",
+    "\n",
+    "- PyGMT produces static vector graphics, whereas Matplotlib has a larger focus on\n",
+    "  interactivity.\n",
+    "\n",
+    "**How does PyGMT differ from Cartopy?**\n",
+    "\n",
+    "- PyGMT is built on GMT's processing and plotting functionality, whereas Cartopy is built on\n",
+    "  Matplotlib's plotting functionality, along with NumPy, Shapely, and PROJ.4.\n",
+    "\n",
+    "### Where is the documentation for PyGMT?\n",
+    "\n",
+    "- The documentation is located at https://www.pygmt.org/latest/index.html.\n",
+    "- To view the documentation for a different version, use the drop-down menu\n",
+    "  in the upper-left corner or the links in the\n",
+    "  [compatibility table](https://www.pygmt.org/latest/index.html#compatibility-with-gmt-python-numpy-versions).\n",
+    "- The unstable [dev docs](https://www.pygmt.org/dev/index.html) reflect the\n",
+    "  [main branch](https://github.com/GenericMappingTools/pygmt) on Github and\n",
+    "  should be referred to when developing PyGMT.\n",
+    "- If you are working in a Jupyter Notebook, you can also view the docstrings for\n",
+    "  PyGMT functions by clicking shift-tab after typing in the function name (and\n",
+    "  you can use tab-completion to finish function names).\n",
+    "\n",
+    "### Warning about PyGMT\n",
+    "\n",
+    "PyGMT is undergoing rapid development. This makes now a great time to get involved with the\n",
+    "PyGMT Community to help shape the future of the project. It also means that all of the\n",
+    "application program interface (API; i.e., how you interact with PyGMT), is subject to\n",
+    "non-backward compatible changes. Non-backward compatible means that the workflows\n",
+    "that you create today are not guaranteed to work in the future, although the PyGMT\n",
+    "[deprecation policy](https://www.pygmt.org/v0.4.1/maintenance.html#backwards-compatibility-and-deprecation-policy)\n",
+    "includes the goals of providing warning about these changes and only making necessary\n",
+    "changes."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "23c87992-51d1-499c-9104-356c43f4d9e4",
+   "metadata": {},
+   "source": [
+    "## 2.1 Load x,y,z data into a pandas.DataFrame\n",
+    "\n",
+    "PyGMT excels at processing and plotting geographic data. The first few sections of this\n",
+    "tutorial cover some processing capabilities of PyGMT while the last sections cover\n",
+    "plotting capabilities. First, let's get started by loading in some sample data using\n",
+    "one of PyGMT's [functions to load sample datasets](https://www.pygmt.org/v0.4.1/api/index.html#datasets)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c8fc945e-06b2-4e03-b5ae-633718f7dd3d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pygmt"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e18b60d1-2541-4947-927d-6c5ac8e9e503",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Load a table of ship bathymetric observations off Baja California\n",
+    "\n",
+    "# Return a summary about the dataset using pandas.DataFrame.describe\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e05e2d84-7f5e-4b58-81c1-86999f628a95",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Use pygmt.info to store the x/y range of data values rounded to the nearest degree\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a8cfd14a-47d1-4835-b38c-2138916c516c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Store the min and max values from the bathymetry\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bc86cb44-b0c6-4373-98f6-a465a5273108",
+   "metadata": {},
+   "source": [
+    "## 2.2 Plot tabular data\n",
+    "\n",
+    "Let's plot the x,y,z data! The basic steps for plotting in\n",
+    "PyGMT are to create an instance of the [Figure](https://www.pygmt.org/v0.4.1/api/generated/pygmt.Figure.html#pygmt.Figure)\n",
+    "class and use its plotting methods. The first time that you\n",
+    "call a plotting method, you will probably want to use\n",
+    "these three parameters:\n",
+    "\n",
+    "- The ``frame`` parameter.\n",
+    "  - This parameter controls the appearance of the map frame\n",
+    "    boundary.\n",
+    "  - For simple, automatic frame settings you can use ``frame=True``.\n",
+    "  - There's a lot the frame parameter can do. We'll learn more\n",
+    "    later, or you can check out the [frame tutorial](https://www.pygmt.org/v0.4.1/tutorials/frames.html).\n",
+    "- The ``region`` parameter.\n",
+    "  - This parameter controls the boundaries of the plot, usually\n",
+    "    by accepting an array in the form `[xmin, xmax, ymin, ymax]`.\n",
+    "  - There are a few special options for the ``region`` parameter,\n",
+    "    which you can learn about in the [region tutorial](https://www.pygmt.org/v0.4.1/tutorials/regions.html).\n",
+    "- The ``projection`` parameter.\n",
+    "  - This parameter controls how your data are mapped onto a 2D\n",
+    "    plot. The control over projection is what sets libraries\n",
+    "    like PyGMT and Cartopy apart from libraries focused on\n",
+    "    visualizing non-geographic datasets. There are many projections\n",
+    "    options listed in the [projections table](https://www.pygmt.org/v0.4.1/projections/index.html#projection-table)\n",
+    "    with examples shown in the [projections gallery](https://www.pygmt.org/v0.4.1/projections/index.html).\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a8c33655-5ce9-4776-b60f-b5135f882f89",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Make a quick plot of the data\n",
+    "# Create an instance of the pygmt.Figure class\n",
+    "\n",
+    "# Plot the data on the figure using 1 point, blue circles\n",
+    "\n",
+    "# Display the figure\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e1453bb8-c656-4cb1-b98a-2e0dd9843607",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "### Plot tabular data with symbols colored by data values\n",
+    "We'll use the same [pygmt.Figure.plot](https://www.pygmt.org/v0.4.1/api/generated/pygmt.Figure.plot.html)\n",
+    "method with the symbol color depending on the z-value, by using\n",
+    "[pygmt.makecpt](https://www.pygmt.org/v0.4.1/api/generated/pygmt.makecpt.html) to\n",
+    "create a colormap using one of the\n",
+    "[Scientific Colour Maps](https://www.fabiocrameri.ch/colourmaps/)\n",
+    "available through GMT and setting ``cmap=True`` in ``pygmt.Figure.plot``.\n",
+    "For the full list of built-in colourmaps in GMT, see\n",
+    "https://docs.generic-mapping-tools.org/6.2/cookbook/cpts.html#id3."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bb57d59e-d6b4-4b3f-984f-8bc7b2944a17",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Make a quick plot of the data with the symbols colored by elevation\n",
+    "# Create an instance of the pygmt.Figure class\n",
+    "\n",
+    "# Create a colormap for the data using pygmt.makecpt\n",
+    "\n",
+    "# Plot the data on the figure using 2 point circles (`style=\"c2p\"`)\n",
+    "\n",
+    "# Display the figure\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1993f22c-178e-47ac-b08c-09f5f0fb8264",
+   "metadata": {},
+   "source": [
+    "### Add colorbar to a PyGMT map\n",
+    "\n",
+    "We'll use the [pygmt.Figure.colorbar](https://www.pygmt.org/v0.4.1/api/generated/pygmt.Figure.colorbar.html) method to add a colorbar\n",
+    "to the plot of the x,y,z data."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "519972bd-3c57-472a-8d54-50020dde02b5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Add a colorbar to the figure with the label \"Elevation (m)\"\n",
+    "\n",
+    "# Display the figure\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cd441d9e-5a8f-4a7e-90f3-c9e6d68d7da6",
+   "metadata": {},
+   "source": [
+    "### Add coastlines a PyGMT map\n",
+    "\n",
+    "To get more context about the data locations, we'll use the\n",
+    "[pygmt.Figure.coast](https://www.pygmt.org/v0.4.1/api/generated/pygmt.Figure.coast.html)\n",
+    "method to plot coastlines."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "60a8022f-3372-4c09-b4db-3f31435dc2ab",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Plot coastlines using pygmt.Figure.coast\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9cf33f65-eb44-4f24-b1f4-bfe957f341ce",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "## 2.3 Grid x,y,z data\n",
+    "\n",
+    "There are many different ways to grid irregularly-spaced x,y,z data. Here we'll use\n",
+    "one workflow for gridding tabular data using PyGMT:\n",
+    "\n",
+    "- Preprocess data using moving median to avoid spatial aliasing and eliminate redundant data\n",
+    "  using [pygmt.blockmedian](https://www.pygmt.org/v0.4.1/api/generated/pygmt.blockmedian.html).\n",
+    "- Use a minimum curvature technique to produce gridded values from x,y,z triplets\n",
+    "  using [pygmt.surface](https://www.pygmt.org/v0.4.1/api/generated/pygmt.surface.html)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e4e85a84-da96-4f20-a522-063204e4abe1",
+   "metadata": {},
+   "source": [
+    "### Block average data using median estimation"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "514953d3-8fd6-4b95-85bd-0f70e9f3255a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Specify 10 arc-minute blocks\n",
+    "\n",
+    "# Compute the median position and value for every non-empty 10 arc-minute block\n",
+    "\n",
+    "# Return a summary about the dataset using pandas.DataFrame.describe\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "646ef26f-8735-4fd3-9d0b-f439df3c951c",
+   "metadata": {},
+   "source": [
+    "### Plot the x,y,z data returned from blockmedian"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a82dcad6-ac8a-4ba4-b1e4-44c849f905d4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Create an instance of the pygmt.Figure class\n",
+    "\n",
+    "# Create a colormap for the data using pygmt.makecpt\n",
+    "\n",
+    "# Plot the data on the figure using 4 point circles (style=\"c4p\")\n",
+    "\n",
+    "# Plot coastlines using pygmt.Figure.coast\n",
+    "\n",
+    "# Add a colorbar to the figure with the label \"Elevation (m)\"\n",
+    "\n",
+    "# Display the figure\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "68f7626b-b23e-4bac-bfab-57ba6e65505c",
+   "metadata": {},
+   "source": [
+    "### Grid the data using continuous curvature splines"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "67536f83-6867-4c23-95f6-7134382387dd",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# First, we need to convert the pandas.DataFrame to a numpy ndarray\n",
+    "\n",
+    "# Produce a grid from the x,y,z data using pygmt.surfae with 10 arc-minute grid spacing\n",
+    "\n",
+    "# Inspect the xarray.dataarray returned from pygmt.surface\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bc97356e-e8de-48c1-8717-6268ca79d4ae",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "## 2.4 Plot gridded data\n",
+    "\n",
+    "One of the most common methods to plot gridded data with\n",
+    "PyGMT is using the [pygmt.Figure.grdimage](https://www.pygmt.org/v0.4.1/api/generated/pygmt.Figure.grdimage.html)\n",
+    "method. As with before, we'll use the ``region``, ``projection``, and\n",
+    "``frame`` parameters to control the map appearance. We'll\n",
+    "also use the [pygmt.Figure.grdcontour](https://www.pygmt.org/v0.4.1/api/generated/pygmt.Figure.grdcontour.html)\n",
+    "method to plot contour lines of the gridded data."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "04caf977-f9ab-4fb3-a031-7267727dab38",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Create an instance of the pygmt.Figure class\n",
+    "\n",
+    "# Create a colormap for the data using pygmt.makecpt\n",
+    "\n",
+    "# Plot the gridded data using pygmt.Figure.grdimage\n",
+    "\n",
+    "# Overlay contours from the gridded data\n",
+    "\n",
+    "# Plot coastlines using pygmt.Figure.coast\n",
+    "\n",
+    "# Add a colorbar to the figure with the label \"Elevation (m)\"\n",
+    "\n",
+    "# Display the figure\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "60678988-b2fc-4001-aded-40c8b41f793e",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "## 3.1 Add scale bar\n",
+    "\n",
+    "In addition to the colorbar added in the last section, there are\n",
+    "several other features that you can add to maps using PyGMT, including\n",
+    "scale bars. We'll use the `map_scale` parameter from\n",
+    "[pygmt.Figure.basemap](https://www.pygmt.org/v0.4.1/api/generated/pygmt.Figure.basemap.html)\n",
+    "to draw the scale bar."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "93f4abae-eac7-42f3-a3c3-54ccbf90198e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Add a scale bar that is 100 km wide\n",
+    "\n",
+    "# Display the figure\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fd16b4df-8089-4df6-9665-75584370ccf3",
+   "metadata": {},
+   "source": [
+    "## 3.2 Add map inset\n",
+    "\n",
+    "To show the location of the map from a global perspective, we\n",
+    "will add an inset map that shows the region of the full figure\n",
+    "using [pygmt.Figure.inset](https://www.pygmt.org/v0.4.1/api/generated/pygmt.Figure.inset.html)\n",
+    "in a  context manager (i.e., using a with statement)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "96b51e9c-ae6e-4396-a08e-990d4d7270c8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Create an inset map\n",
+    "\n",
+    "# Plot coastlines\n",
+    "\n",
+    "# Plot a rectangle (\"r\") in the inset map to show the area of the main figure.\n",
+    "\n",
+    "# Display the figure\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "958eae96-ee6b-4941-b1e8-fb0815e425a1",
+   "metadata": {},
+   "source": [
+    "## 4.1 Create subplots\n",
+    "\n",
+    "Subplots provide a useful way to plot related visualizations in a\n",
+    "single figure. We'll use the [pygmt.Figure.subplot](https://www.pygmt.org/v0.4.1/api/generated/pygmt.Figure.subplot.html)\n",
+    "method to create four panels in a 2x2 layout."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "87b006d6-7388-4d71-bbe9-f9ecb243c853",
+   "metadata": {
+    "lines_to_next_cell": 2
+   },
+   "outputs": [],
+   "source": [
+    "# Load earth relief data\n",
+    "\n",
+    "# Create an instance of the pygmt.Figure class\n",
+    "\n",
+    "# Create a colormap to use in all figures\n",
+    "\n",
+    "# Create subplots with 2 rows and 2 columns\n",
+    "\n",
+    "# Use the fig.set_panel method to select the first panel\n",
+    "\n",
+    "# Plot the original data\n",
+    "\n",
+    "# Use the fig.set_panel method to select the second panel\n",
+    "\n",
+    "# Plot the data returned from pygmt.blockmedian\n",
+    "\n",
+    "# Use the fig.set_panel method to select the third panel\n",
+    "\n",
+    "# Plot the data returned from pygmt.surface\n",
+    "\n",
+    "# Use the fig.set_panel method to select the fourth panel\n",
+    "\n",
+    "# Plot the earth relief data provided by PyGMT\n",
+    "\n",
+    "# Add a colorbar to the figure\n",
+    "\n",
+    "# Display the figure\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9c1ce253-1b4f-4d96-97e9-7b6b43b07d09",
+   "metadata": {},
+   "source": [
+    "## 5.1 Configure PyGMT settings\n",
+    "\n",
+    "PyGMT settings can be customized using [pygmt.config](https://www.pygmt.org/v0.4.1/api/generated/pygmt.config.html#pygmt.config).\n",
+    "More instructions are offered in the [configuring PyGMT defaults tutorial](https://www.pygmt.org/v0.4.1/tutorials/configuration.html).\n",
+    "The full list of configurable settings can be found in the [GMT configuration documentation](https://docs.generic-mapping-tools.org/latest/gmt.conf.html)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "58ba6ffd-d6f0-490d-be49-4f3fd054d622",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Create two coastline plots\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "64f65a85-5ab4-4c40-a93a-6cb2a7be146a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Change the font size for annotations to 20 points\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "62d71204-20c2-4253-a68f-c08b1ecb3015",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Change the font size for annotations to 20 points\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/refresher/pygmt_template.ipynb
+++ b/refresher/pygmt_template.ipynb
@@ -101,7 +101,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import pygmt"
+    "# Import pygmt\n"
    ]
   },
   {


### PR DESCRIPTION
This empty template for the PyGMT tutorial will be used to moderate the pace of the webinar by live coding the examples.